### PR TITLE
Adds configure option to disable the experimental multiple global ref…

### DIFF
--- a/.vscode_shared/BenHimes/tasks.json
+++ b/.vscode_shared/BenHimes/tasks.json
@@ -15,7 +15,7 @@
         {
             "label": "CONFIG intel,debug,static",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-debug-static && cd ${build_dir}/intel-debug-static && CC=icc CXX=icpc ../../configure --enable-debugmode --enable-staticmode --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_static}"
+            "command": "mkdir -p ${build_dir}/intel-debug-static && cd ${build_dir}/intel-debug-static && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements --enable-debugmode --enable-staticmode --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_static}"
         },
         {
             "label": "BUILD intel,debug,static",
@@ -25,7 +25,7 @@
         {
             "label": "CONFIG intel,static",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-static && cd ${build_dir}/intel-static && CC=icc CXX=icpc ../../configure  --enable-staticmode --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_static}"
+            "command": "mkdir -p ${build_dir}/intel-static && cd ${build_dir}/intel-static && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements --enable-staticmode --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_static}"
         },
         {
             "label": "BUILD intel,static",
@@ -35,7 +35,7 @@
         {
             "label": "CONFIG intel,gpu,debug,static",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-gpu-debug-static && cd ${build_dir}/intel-gpu-debug-static && CC=icc CXX=icpc ../../configure  --enable-debugmode --enable-staticmode --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_static}"
+            "command": "mkdir -p ${build_dir}/intel-gpu-debug-static && cd ${build_dir}/intel-gpu-debug-static && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements --enable-debugmode --enable-staticmode --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_static}"
         },
         {
             "label": "BUILD intel,gpu,debug,static",
@@ -45,7 +45,7 @@
         {
             "label": "CONFIG intel,gpu,static",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-gpu-static && cd ${build_dir}/intel-gpu-static && CC=icc CXX=icpc ../../configure  --enable-staticmode --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_static}"
+            "command": "mkdir -p ${build_dir}/intel-gpu-static && cd ${build_dir}/intel-gpu-static && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements --enable-staticmode --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_static}"
         },
         {
             "label": "BUILD intel,gpu,static",
@@ -55,7 +55,7 @@
         {
             "label": "CONFIG intel,debug,dynamic",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-debug-dynamic && cd ${build_dir}/intel-debug-dynamic && CC=icc CXX=icpc ../../configure  --enable-debugmode  --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_dynamic}"
+            "command": "mkdir -p ${build_dir}/intel-debug-dynamic && cd ${build_dir}/intel-debug-dynamic && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements --enable-debugmode  --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_dynamic}"
         },
         {
             "label": "BUILD intel,debug,dynamic",
@@ -65,7 +65,7 @@
         {
             "label": "CONFIG intel,dynamic",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-dynamic && cd ${build_dir}/intel-dynamic && CC=icc CXX=icpc ../../configure   --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_dynamic}"
+            "command": "mkdir -p ${build_dir}/intel-dynamic && cd ${build_dir}/intel-dynamic && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements  --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_dynamic}"
         },
         {
             "label": "BUILD intel,dynamic",
@@ -75,7 +75,7 @@
         {
             "label": "CONFIG intel,gpu,debug,dynamic",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-gpu-debug-dynamic && cd ${build_dir}/intel-gpu-debug-dynamic && CC=icc CXX=icpc ../../configure  --enable-gpu-debug --enable-debugmode  --with-cuda=${cuda_dir} --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_dynamic}"
+            "command": "mkdir -p ${build_dir}/intel-gpu-debug-dynamic && cd ${build_dir}/intel-gpu-debug-dynamic && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements --enable-gpu-debug --enable-debugmode  --with-cuda=${cuda_dir} --enable-samples --enable-experimental --enable-openmp --with-wx-config=${wx_dir_dynamic}"
         },
         {
             "label": "BUILD intel,gpu,debug,dynamic",
@@ -85,7 +85,7 @@
         {
             "label": "CONFIG intel,gpu,dynamic",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/intel-gpu-dynamic && cd ${build_dir}/intel-gpu-dynamic && CC=icc CXX=icpc ../../configure   --with-cuda=${cuda_dir} --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_dynamic}"
+            "command": "mkdir -p ${build_dir}/intel-gpu-dynamic && cd ${build_dir}/intel-gpu-dynamic && CC=icc CXX=icpc ../../configure --disable-multiple-global-refinements  --with-cuda=${cuda_dir} --enable-experimental --enable-samples  --enable-openmp --with-wx-config=${wx_dir_dynamic}"
         },
         {
             "label": "BUILD intel,gpu,dynamic",
@@ -95,7 +95,7 @@
         {
             "label": "CONFIG GNU ,gpu",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/GNU-gpu && cd ${build_dir}/GNU-gpu && CC=gcc CXX=g++ ../../configure --enable-samples --enable-experimental --with-cuda=${cuda_dir} --disable-staticmode --enable-openmp"
+            "command": "mkdir -p ${build_dir}/GNU-gpu && cd ${build_dir}/GNU-gpu && CC=gcc CXX=g++ ../../configure --disable-multiple-global-refinements--enable-samples --enable-experimental --with-cuda=${cuda_dir} --disable-staticmode --enable-openmp"
         },
         {
             "label": "BUILD GNU,gpu",
@@ -105,7 +105,7 @@
         {
             "label": "CONFIG GNU,gpu, debug",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/GNU-gpu-debug && cd ${build_dir}/GNU-gpu-debug && CC=gcc CXX=g++ ../../configure --enable-samples --enable-debugmode --enable-experimental --with-cuda=/usr/local/cuda --disable-staticmode --enable-openmp"
+            "command": "mkdir -p ${build_dir}/GNU-gpu-debug && cd ${build_dir}/GNU-gpu-debug && CC=gcc CXX=g++ ../../configure --disable-multiple-global-refinements --enable-samples --enable-debugmode --enable-experimental --with-cuda=/usr/local/cuda --disable-staticmode --enable-openmp"
         },
         {
             "label": "BUILD GNU,gpu, debug",

--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ CUDA_CPP_STANDARD=17
 AC_ARG_ENABLE([warnings], AS_HELP_STRING([--disable compiler warnings], [Default=false]), 
 [
 	# If flag do this
-	if test "x$enableval" = "no" ; then
+	if test "x$enableval" = "xno" ; then
 		WARNINGS_ON="-w"		
 	else
 		if test "x$CXX" = "xicpc"; then		
@@ -90,6 +90,12 @@ AC_ARG_ENABLE([warnings], AS_HELP_STRING([--disable compiler warnings], [Default
 			WARNINGS_ON="-Wall"	
 		fi	
 ])
+
+AC_ARG_ENABLE(multiple-global-refinements, AS_HELP_STRING([--disable-multiple-global-refinements],[Only do one global search in AutoRefine3d [default=no]]),[
+	if test "x$enableval" = "xno" ; then
+		AC_DEFINE([DISABLE_MUTLI_GLOBAL_REFINEMENTS], [ ], [Disable multiple rounds of global refinement in AutoRefine3d])
+  fi
+]) # No action needed if flag is not present as multiple global refinements is the default.
 
 
 # The cpp std is currently diffent between cuda and gcc so we set this at the end

--- a/src/gui/AutoRefine3dPanel.cpp
+++ b/src/gui/AutoRefine3dPanel.cpp
@@ -1,5 +1,13 @@
 #include "../core/gui_core_headers.h"
 
+// Rather than re-write the blocks that add rounds of global alignment after round 1, we override the booleans they set to true,
+// when cisTEM is configured to do so by --disable-multiple-global-refinements
+#ifndef DISABLE_MUTLI_GLOBAL_REFINEMENTS
+constexpr bool true_if_not_configured_as_disabled = true;
+#else
+constexpr bool true_if_not_configured_as_disabled = false;
+#endif
+
 extern MyRefinementPackageAssetPanel* refinement_package_asset_panel;
 extern MyRunProfilesPanel*            run_profiles_panel;
 extern MyVolumeAssetPanel*            volume_asset_panel;
@@ -351,6 +359,7 @@ void AutoRefine3DPanel::SetDefaults( ) {
         SearchRangeYTextCtrl->SetValue(wxString::Format("%.2f", search_range));
 
         InnerMaskRadiusTextCtrl->SetValue("0.00");
+        TargetResolutionTextCtrl->SetValue("0.00");
 
         AutoCropYesRadioButton->SetValue(false);
         AutoCropNoRadioButton->SetValue(true);
@@ -770,6 +779,7 @@ void AutoRefinementManager::BeginRefinementCycle( ) {
     active_mask_radius              = my_parent->MaskRadiusTextCtrl->ReturnValue( );
     active_global_mask_radius       = my_parent->GlobalMaskRadiusTextCtrl->ReturnValue( );
     active_inner_mask_radius        = my_parent->InnerMaskRadiusTextCtrl->ReturnValue( );
+    active_target_resolution        = my_parent->TargetResolutionTextCtrl->ReturnValue( );
     active_number_results_to_refine = my_parent->NumberToRefineSpinCtrl->GetValue( );
     active_search_range_x           = my_parent->SearchRangeXTextCtrl->ReturnValue( );
     active_search_range_y           = my_parent->SearchRangeYTextCtrl->ReturnValue( );
@@ -1297,6 +1307,13 @@ void AutoRefinementManager::SetupRefinementJob( ) {
     float likelihood_to_global;
     bool  do_global_for_this_particle;
 
+    // Just to make sure it is working
+    if ( true_if_not_configured_as_disabled ) {
+        wxPrintf("Allowing multiple global refinements\n");
+    }
+    else {
+        wxPrintf("Disallowing multiple global refinements\n");
+    }
     // get the last refinement for the currently selected refinement package..
 
     wxArrayString written_parameter_files;
@@ -1316,7 +1333,7 @@ void AutoRefinementManager::SetupRefinementJob( ) {
         if ( number_of_rounds_run == 0 )
             do_global_for_this_particle = true;
         else if ( resolution_per_round[resolution_per_round.GetCount( ) - 1] < 5.0f && lowest_alignment_res <= 8.0f && resolution_of_last_global_alignment[particle_counter] > 9.0f && reference_3d_contains_all_particles == true && number_of_rounds_run > 2 )
-            do_global_for_this_particle = true;
+            do_global_for_this_particle = true_if_not_configured_as_disabled;
         else {
 
             // should we do local or global? Randonly decide..
@@ -1336,7 +1353,7 @@ void AutoRefinementManager::SetupRefinementJob( ) {
                 likelihood_to_global = powf(lowest_alignment_res, 2) / ((1000.0f / res_adjust) * round_adjust); // very arbritrary
 
             if ( fabsf(global_random_number_generator.GetUniformRandom( )) < likelihood_to_global )
-                do_global_for_this_particle = true;
+                do_global_for_this_particle = true_if_not_configured_as_disabled;
             else
                 do_global_for_this_particle = false;
         }

--- a/src/gui/AutoRefine3dPanel.h
+++ b/src/gui/AutoRefine3dPanel.h
@@ -30,6 +30,7 @@ class AutoRefinementManager {
     float active_search_range_x;
     float active_search_range_y;
     float active_inner_mask_radius;
+    float active_target_resolution;
     bool  active_should_apply_blurring;
     float active_smoothing_factor;
     bool  active_auto_crop;

--- a/src/gui/ProjectX_gui.cpp
+++ b/src/gui/ProjectX_gui.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version 3.10.0-4761b0c)
+// C++ code generated with wxFormBuilder (version 3.10.1-0-g8feb16b)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -8976,15 +8976,6 @@ AutoRefine3DPanelParent::AutoRefine3DPanelParent( wxWindow* parent, wxWindowID i
 	bSizer441->Fit( InputParamsPanel );
 	bSizer364->Add( InputParamsPanel, 1, wxEXPAND | wxALL, 5 );
 
-
-	bSizer451->Add( bSizer364, 1, wxEXPAND, 5 );
-
-
-	bSizer43->Add( bSizer451, 0, wxEXPAND, 5 );
-
-	wxBoxSizer* bSizer46;
-	bSizer46 = new wxBoxSizer( wxHORIZONTAL );
-
 	ExpertPanel = new wxScrolledWindow( this, wxID_ANY, wxDefaultPosition, wxSize( -1,-1 ), wxVSCROLL );
 	ExpertPanel->SetScrollRate( 5, 5 );
 	ExpertPanel->Hide();
@@ -9043,6 +9034,13 @@ AutoRefine3DPanelParent::AutoRefine3DPanelParent( wxWindow* parent, wxWindowID i
 
 	InnerMaskRadiusTextCtrl = new NumericTextCtrl( ExpertPanel, wxID_ANY, wxT("0.00"), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
 	fgSizer1->Add( InnerMaskRadiusTextCtrl, 0, wxALL|wxEXPAND, 5 );
+
+	m_staticText3301 = new wxStaticText( ExpertPanel, wxID_ANY, wxT("Target Resolution (Å) :"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText3301->Wrap( -1 );
+	fgSizer1->Add( m_staticText3301, 0, wxALL, 5 );
+
+	TargetResolutionTextCtrl = new NumericTextCtrl( ExpertPanel, wxID_ANY, wxT("0.00"), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER );
+	fgSizer1->Add( TargetResolutionTextCtrl, 0, wxALL|wxEXPAND, 5 );
 
 	m_staticText201 = new wxStaticText( ExpertPanel, wxID_ANY, wxT("Global Search"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText201->Wrap( -1 );
@@ -9214,7 +9212,16 @@ AutoRefine3DPanelParent::AutoRefine3DPanelParent( wxWindow* parent, wxWindowID i
 	ExpertPanel->SetSizer( InputSizer );
 	ExpertPanel->Layout();
 	InputSizer->Fit( ExpertPanel );
-	bSizer46->Add( ExpertPanel, 0, wxALL|wxEXPAND, 5 );
+	bSizer364->Add( ExpertPanel, 0, wxALL|wxEXPAND, 5 );
+
+
+	bSizer451->Add( bSizer364, 1, wxEXPAND, 5 );
+
+
+	bSizer43->Add( bSizer451, 0, wxEXPAND, 5 );
+
+	wxBoxSizer* bSizer46;
+	bSizer46 = new wxBoxSizer( wxHORIZONTAL );
 
 	OutputTextPanel = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
 	OutputTextPanel->Hide();

--- a/src/gui/ProjectX_gui.h
+++ b/src/gui/ProjectX_gui.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version 3.10.0-4761b0c)
+// C++ code generated with wxFormBuilder (version 3.10.1-0-g8feb16b)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -2320,6 +2320,8 @@ class AutoRefine3DPanelParent : public JobPanel
 		NumericTextCtrl* MaskRadiusTextCtrl;
 		wxStaticText* m_staticText330;
 		NumericTextCtrl* InnerMaskRadiusTextCtrl;
+		wxStaticText* m_staticText3301;
+		NumericTextCtrl* TargetResolutionTextCtrl;
 		wxStaticText* m_staticText201;
 		wxStaticText* GlobalMaskRadiusStaticText;
 		NumericTextCtrl* GlobalMaskRadiusTextCtrl;


### PR DESCRIPTION
…inements that are supposed to make AutoRefine3d more robust. In general, this should be left alone, hence a disable option.

# Description

Tim has added extra rounds of global refinement in AutoRefine3d around commit f4073D8 (march 2020) starting always in round 3 and then also at random times later. This causes a major slow down if you get to a high res in round 3.

This PR makes this behavior configurable via a --disable-multiple-global-refinements flag

# Fixes 
 

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# These changes are isolated to the

- [X] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# This build was done using the cistem_build_env docker container

- [X] yes
- [ ] no

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
