### PR TITLE
Compiles fine

### DIFF
--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -200,11 +200,6 @@ class StackDump : public wxStackWalker // so we can give backtraces..
 #include <typeinfo>
 #include <limits>
 
-// These headers are need so that gpu specific types can be instantiated outside the if(use_gpu) brackets.
-#include "../gpu/DeviceManager.h"
-#include "../gpu/GpuImage.h"
-#include "../gpu/Histogram.h"
-#include "../gpu/TemplateMatchingCore.h"
 #endif
 
 #ifdef MKL

--- a/src/gpu/DeviceManager.cu
+++ b/src/gpu/DeviceManager.cu
@@ -1,4 +1,5 @@
 #include "gpu_core_headers.h"
+#include "DeviceManager.h"
 
 DeviceManager::DeviceManager( ){
 
@@ -152,6 +153,7 @@ void DeviceManager::ListDevices( ) {
         wxPrintf("  Memory bandwidth (GB/s): %f\n", 2.0 * prop.memoryClockRate * (prop.memoryBusWidth / 8) / 1.0e6);
         wxPrintf("  Number of multiprocessors: %d\n", prop.multiProcessorCount);
         wxPrintf("  Threads per multiprocessor: %d\n", prop.maxThreadsPerMultiProcessor);
+        wxPrintf("  Maximum 3dArray size: %i, %i, %i\n", prop.maxSurface3D[0], prop.maxSurface3D[1], prop.maxSurface3D[2]); // for texture cache
         // wxPrintf("  Memory per multiprocessor (GB): %f\n", float(prop.sharedMemPerMultiprocessor) / 1024 / 1024 / 1024);
         wxPrintf("  Memory on device (GB): %f\n", float(prop.totalGlobalMem) / 1024 / 1024 / 1024);
         wxPrintf("  Free memory (GB): %f\n", float(free_mem) / 1024 / 1024 / 1024);

--- a/src/gpu/DeviceManager.h
+++ b/src/gpu/DeviceManager.h
@@ -1,4 +1,5 @@
-
+#ifndef _SRC_GPU_DEVICEMANAGER_H_
+#define _SRC_GPU_DEVICEMANAGER_H_
 
 class DeviceManager {
 
@@ -18,3 +19,5 @@ class DeviceManager {
 
   private:
 };
+
+#endif // _SRC_GPU_DEVICEMANAGER_H_

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -8,6 +8,7 @@
 //#include "gpu_core_headers.h"
 
 #include "gpu_core_headers.h"
+#include "GpuImage.h"
 
 __global__ void ConvertToHalfPrecisionKernelComplex(cufftComplex* complex_32f_values, __half2* complex_16f_values, int4 dims, int3 physical_upper_bound_complex);
 __global__ void ConvertToHalfPrecisionKernelReal(cufftReal* real_32f_values, __half* real_16f_values, int4 dims);
@@ -298,9 +299,9 @@ void GpuImage::SetupInitialValues( ) {
     insert_into_which_reconstruction = 0;
     hostImage                        = NULL;
 
-    cudaErr(cudaEventCreateWithFlags(&nppCalcEvent, cudaEventDisableTiming);)
+    cudaErr(cudaEventCreateWithFlags(&nppCalcEvent, cudaEventDisableTiming));
 
-            cudaErr(cudaGetDevice(&device_idx));
+    cudaErr(cudaGetDevice(&device_idx));
     cudaErr(cudaDeviceGetAttribute(&number_of_streaming_multiprocessors, cudaDevAttrMultiProcessorCount, device_idx));
     limit_SMs_by_threads = 1;
 

--- a/src/gpu/Histogram.cu
+++ b/src/gpu/Histogram.cu
@@ -6,6 +6,8 @@
  */
 
 #include "gpu_core_headers.h"
+#include "GpuImage.h"
+#include "Histogram.h"
 
 __global__ void histogram_smem_atomics(const __half* in, int4 dims, float* out, int n_bins, const __half bin_min, const __half bin_inc, const int max_padding);
 

--- a/src/gpu/TemplateMatchingCore.cu
+++ b/src/gpu/TemplateMatchingCore.cu
@@ -1,4 +1,5 @@
 #include "gpu_core_headers.h"
+#include "TemplateMatchingCore.h"
 
 #define DO_HISTOGRAM true
 

--- a/src/gpu/TemplateMatchingCore.h
+++ b/src/gpu/TemplateMatchingCore.h
@@ -1,55 +1,9 @@
 #ifndef TemplateMatchingCore_H_
 #define TemplateMatchingCore_H_
 
-//typedef
-//struct __align__(8) _Peaks {
-//	// This should be 128 byte words, so good for read access?
-//	__half mip;
-//	__half psi;
-//	__half theta;
-//	__half phi;
-//
-//} Peaks;
-
-//typedef
-//struct __align__(8) _Peaks {
-//	// This should be 128 byte words, so good for read access?
-//	__half mip;
-//	__half psi;
-//	__half theta;
-//	__half phi;
-//
-//} Peaks;
-//typedef
-//struct __align__(16) _Peaks {
-//	// This should be 128 byte words, so good for read access?
-//	float mip;
-//	float psi;
-//	float theta;
-//	float phi;
-//
-//} Peaks;
-
-//typedef
-//struct __align__(16)_Stats{
-//	__half mip;
-//	__half psi;
-//	__half theta;
-//	__half phi;
-//	__half mean;
-//	__half sum_sq_diff;
-//	int N;
-//} Stats;
-//typedef
-//struct __align__(8) _Stats{
-//	cufftReal sum;
-//	cufftReal sq_sum;
-//} Stats;
-//typedef
-//	struct __align__(4) _Stats{
-//__half sum;
-//__half sq_sum;
-//} Stats;
+#include "GpuImage.h"
+#include "DeviceManager.h"
+#include "Histogram.h"
 
 class TemplateMatchingCore {
 

--- a/src/gpu/gpu_core_headers.h
+++ b/src/gpu/gpu_core_headers.h
@@ -24,8 +24,9 @@ const int MAX_GPU_COUNT = 32;
 #define postcheck 
 #define precheck 
 #else
-#define nppErr(npp_stat)  {if (npp_stat != NPP_SUCCESS) { wxPrintf("NPP_CHECK_NPP - npp_stat = %s at line %d in file %s\n", _cudaGetErrorEnum(npp_stat), __LINE__,__FILE__); DEBUG_ABORT} };
-#define cudaErr(error) { auto status = static_cast<cudaError_t>(error); if (status != cudaSuccess) { std::cerr << cudaGetErrorString(status) << " :-> "; MyFFTPrintWithDetails(""); DEBUG_ABORT} };
+// For now, you have to look up NPP error codes here https://docs.nvidia.com/cuda/npp/nppdefs_8h_source.html
+#define nppErr(npp_stat)  {if (npp_stat != NPP_SUCCESS) { wxPrintf("NPP_CHECK_NPP - npp_stat = %s at line %d in file %s\n", (npp_stat), __LINE__,__FILE__); DEBUG_ABORT} }
+#define cudaErr(error) { auto status = static_cast<cudaError_t>(error); if (status != cudaSuccess) { std::cerr << cudaGetErrorString(status) << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }
 #define postcheck { cudaErr(cudaPeekAtLastError()); cudaError_t error = cudaStreamSynchronize(cudaStreamPerThread); cudaErr(error); };
 #define precheck { cudaErr(cudaGetLastError()); }
 #endif

--- a/src/programs/gpu_devices/gpu_devices.cpp
+++ b/src/programs/gpu_devices/gpu_devices.cpp
@@ -1,4 +1,5 @@
 #include "../../core/core_headers.h"
+#include "../../gpu/DeviceManager.h"
 
 class
         GpuDevices : public MyApp {

--- a/src/programs/gpu_util_test/gpu_util_test.cpp
+++ b/src/programs/gpu_util_test/gpu_util_test.cpp
@@ -1,4 +1,7 @@
 #include "../../core/core_headers.h"
+#include "DeviceManager.h"
+#include "../../gpu/GpuImage.h"
+#include "../../gpu/TemplateMatchingCore.h"
 
 class
         GpuUtilTest : public MyApp {

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -1,5 +1,7 @@
 #include "../../core/core_headers.h"
 #include "../../core/cistem_constants.h"
+#include "../../gpu/DeviceManager.h"
+#include "../../gpu/TemplateMatchingCore.h"
 
 #ifdef ENABLE_FastFFT
 #include <FastFFT.h>

--- a/src/programs/samples/1_cpu_gpu_comparison/resize_comparison.cpp
+++ b/src/programs/samples/1_cpu_gpu_comparison/resize_comparison.cpp
@@ -16,6 +16,8 @@
 #include "../../../core/core_headers.h"
 #endif
 
+#include "../../../gpu/GpuImage.h"
+
 #include "../common/common.h"
 #include "resize_comparison.h"
 


### PR DESCRIPTION
# Description

Removes all GPU related headers out of core_headers.h

Otherwise, the whole project is recompiled when altering any of the headers which is super painful.

The recipe for this is not too rough in vscode, for a given header just Ctrl+shift f the definitions to see where the are needed and just put the header in those compilation units.

(Of course for some legacy headers e.g. Image.h, this would be a nightmare, but otherwise, this should probably be done whenever significant work is being done on a given class or whatever)

# Fixes 
 No submitted issue, but long compile times when altering GpuImage.h

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [X] gpu core library
- [X] program it modifies

# This build was done using the cistem_build_env docker container

- [X] yes
- [ ] no

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
